### PR TITLE
Corrections sur les armes de jet

### DIFF
--- a/modules/helpers/config.mjs
+++ b/modules/helpers/config.mjs
@@ -331,7 +331,7 @@ PROPHECY.TypeWpn = {
     'double':'PROPHECY.WPN.Double',
     'corpsacorps':'PROPHECY.WPN.Corpsacorps',
     'hast':'PROPHECY.WPN.Hast',
-    'jet':'PROPHECY.WPN.Hast',
+    'jet':'PROPHECY.WPN.Jet',
     'projectile':'PROPHECY.WPN.Projectile',
     'mecanique':'PROPHECY.WPN.Mecanique',
 };

--- a/templates/armement-item-sheet.html
+++ b/templates/armement-item-sheet.html
@@ -23,7 +23,7 @@
                         {{selectOptions item.Mains selected=systemData.mains localize=true sort=true}}
                     </select>
                 </div>
-                {{#if (or (eq systemData.type 'projectile') (eq systemData.type 'mecanique'))}}
+                {{#if (or (eq systemData.type 'projectile') (eq systemData.type 'mecanique') (eq systemData.type 'jet'))}}
                 <label class="portee">
                         <span>{{localize 'PROPHECY.Portee'}} :</span>
                         <input type="text" name="system.portee" value="{{systemData.portee}}" />

--- a/templates/parts/subparts/combatLeft.html
+++ b/templates/parts/subparts/combatLeft.html
@@ -47,7 +47,7 @@
                     <span class="separation">/</span>
                     <span class="score">{{localize 'PROPHECY.INITIATIVE.CC'}} : {{key.system.initiative.cc}}</span>
                 </label>
-                {{#if (or (eq key.system.type 'projectile') (eq key.system.type 'mecanique'))}}
+                {{#if (or (eq key.system.type 'projectile') (eq key.system.type 'mecanique') (eq key.system.type 'jet'))}}
                 <label>
                     <span class="label">{{localize 'PROPHECY.Portee'}}</span>
                     <span class="score">{{key.system.portee}}</span>


### PR DESCRIPTION
2 petites corrections sur les armes de jet :
- Sur la page de création de l'arme, le type Arme de jet est maintenant proposé au lieu d'avoir 2 fois Arme d'hast
- Sur la page de création de l'arme et sur la feuille de personnage, la portée est maintenant affichée pour les armes de jet, comme pour les armes à projectile et les armes mécaniques.