### PR TITLE
Evolution du système de blessure pour les pnj

### DIFF
--- a/lang/eng.json
+++ b/lang/eng.json
@@ -239,6 +239,11 @@
           "Grave":"grave",
           "Fatale":"fatale",
           "Mort":"mort",
+          "ExtendedMode":"Extended mode",
+          "DefaultLabel":"Standard threshold",
+          "CustomLabel":"Displayed label",
+          "MaxThreshold":"Max threshold",
+          "Boxes":"Number of boxes",
           "Subir":"Subir une blessure de ce type",
           "Soin":"Soigner une blessure de ce type"
         }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -239,6 +239,11 @@
           "Grave":"grave",
           "Fatale":"fatale",
           "Mort":"mort",
+          "ExtendedMode":"Mode étendu",
+          "DefaultLabel":"Seuil standard",
+          "CustomLabel":"Libellé affiché",
+          "MaxThreshold":"Seuil max",
+          "Boxes":"Nombre de cases",
           "Subir":"Subir une blessure de ce type",
           "Soin":"Soigner une blessure de ce type"
         }

--- a/modules/documents/models/base/blessures-data-model.mjs
+++ b/modules/documents/models/base/blessures-data-model.mjs
@@ -1,3 +1,53 @@
+const BLESSURE_ORDER = ['egratinures', 'legeres', 'graves', 'fatales', 'morts'];
+
+const BLESSURE_DEFAULTS = {
+	egratinures: {
+		label: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Egratinure',
+		max: 10,
+	},
+	legeres: {
+		label: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Legere',
+		max: 20,
+	},
+	graves: {
+		label: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Grave',
+		max: 30,
+	},
+	fatales: {
+		label: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Fatale',
+		max: 40,
+	},
+	morts: {
+		label: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Mort',
+		max: null,
+	},
+};
+
+function duplicateData(data) {
+	return foundry.utils.deepClone(data);
+}
+
+function createExtendedThreshold(type, value = 0, check = {}) {
+	const defaults = BLESSURE_DEFAULTS[type];
+
+	return {
+		label: defaults.label,
+		max: defaults.max,
+		value,
+		check: duplicateData(check ?? {}),
+	};
+}
+
+function createExtendedData() {
+	const data = {};
+
+	for(const type of BLESSURE_ORDER) {
+		data[type] = createExtendedThreshold(type);
+	}
+
+	return data;
+}
+
 export class BlessureDataModel extends foundry.abstract.DataModel {
 	static defineSchema() {
 		const { SchemaField, NumberField, ObjectField, BooleanField } = foundry.data.fields;
@@ -25,6 +75,8 @@ export class BlessureDataModel extends foundry.abstract.DataModel {
 				}),
 			}),
 			edit: new BooleanField({ initial: false}),
+			etendu: new BooleanField({ initial: false}),
+			extended: new ObjectField({ initial: createExtendedData() }),
 			malus: new NumberField({ initial: 0, integer: true, nullable: false}),
 		};
 	}
@@ -33,8 +85,172 @@ export class BlessureDataModel extends foundry.abstract.DataModel {
 		super._initialize(options);
 	}
 
+	get actor() {
+		return this.parent.parent;
+	}
+
+	get isExtended() {
+		return this.actor.actor.type === 'pnj' && this.etendu;
+	}
+
+	get displayData() {
+		return this.getDisplayData();
+	}
+
+	getExtendedThreshold(type) {
+		if(!this.extended?.[type]) this.extended[type] = createExtendedThreshold(type);
+
+		const threshold = this.extended[type];
+		const data = this.data[type];
+		const label = threshold.label || BLESSURE_DEFAULTS[type].label;
+		const max = threshold.max === '' || threshold.max === undefined ? BLESSURE_DEFAULTS[type].max : threshold.max;
+
+		threshold.label = label;
+		threshold.max = max;
+		threshold.value = Number.isInteger(threshold.value) ? threshold.value : (data?.value ?? 0);
+		threshold.check = duplicateData(threshold.check ?? data?.check ?? {});
+
+		return threshold;
+	}
+
+	getThresholdData(type) {
+		return this.isExtended ? this.getExtendedThreshold(type) : this.data[type];
+	}
+
+	prepareExtendedData() {
+		if(!this.extended) this.extended = createExtendedData();
+
+		for(const type of BLESSURE_ORDER) {
+			const threshold = this.getExtendedThreshold(type);
+			threshold.value = Number.isInteger(threshold.value) ? Math.max(threshold.value, 0) : 0;
+			threshold.max = threshold.max === null || threshold.max === '' ? null : parseInt(threshold.max);
+			threshold.check = this.prepareThresholdCheck(threshold.check, threshold.value);
+		}
+	}
+
+	prepareThresholdCheck(currentCheck = {}, value = 0) {
+		let prepared = {};
+
+		for(let i = 1;i <= value;i++) {
+			prepared[`c${i}`] = currentCheck?.[`c${i}`] ?? false;
+		}
+
+		return prepared;
+	}
+
+	getThresholdLabel(type) {
+		if(this.isExtended) {
+			const label = this.getExtendedThreshold(type).label;
+			return label?.startsWith('PROPHECY.') ? game.i18n.localize(label) : label;
+		}
+
+		return game.i18n.localize(CONFIG.PROPHECY.Blessures[type]);
+	}
+
+	getDisplayData() {
+		const entries = [];
+		let start = 1;
+
+		for(const type of BLESSURE_ORDER) {
+			const threshold = this.getThresholdData(type);
+			const value = threshold?.value ?? 0;
+			const visible = !this.isExtended || value > 0;
+
+			if(!visible) continue;
+
+			const entry = {
+				type,
+				value,
+				check: threshold.check ?? {},
+				label: this.getThresholdLabel(type),
+				range: this.isExtended ? this.getExtendedRange(type, start) : CONFIG.PROPHECY.SeuilsBlessures[type],
+			};
+
+			entries.push(entry);
+
+			if(this.isExtended) {
+				const max = this.getExtendedThreshold(type).max;
+
+				if(Number.isInteger(max)) start = max + 1;
+			}
+		}
+
+		return entries;
+	}
+
+	getExtendedRange(type, start) {
+		const threshold = this.getExtendedThreshold(type);
+		const visibleTypes = BLESSURE_ORDER.filter(currentType => (this.getThresholdData(currentType)?.value ?? 0) > 0);
+		const isLastVisible = visibleTypes[visibleTypes.length - 1] === type;
+		const max = threshold.max;
+
+		if(isLastVisible) {
+			return `(${start}+)`;
+		}
+
+		if(Number.isInteger(max) && max >= start) {
+			return `(${start} - ${max})`;
+		}
+
+		return `(${start}+)`;
+	}
+
+	getThresholdTypeFromDamage(totaldmg) {
+		if(!this.isExtended) {
+			if(totaldmg <= 10) return 'egratinures';
+			if(totaldmg <= 20) return 'legeres';
+			if(totaldmg <= 30) return 'graves';
+			if(totaldmg <= 40) return 'fatales';
+			return 'morts';
+		}
+
+		const visibleTypes = BLESSURE_ORDER.filter(type => (this.getThresholdData(type)?.value ?? 0) > 0);
+
+		if(visibleTypes.length === 0) return 'morts';
+
+		for(const type of visibleTypes) {
+			const max = this.getExtendedThreshold(type).max;
+
+			if(!Number.isInteger(max)) return type;
+			if(totaldmg <= max) return type;
+		}
+
+		return visibleTypes[visibleTypes.length - 1];
+	}
+
+	findNextAvailableThreshold(startType = 'egratinures') {
+		let currentType = startType;
+
+		while(currentType !== 'end') {
+			const data = this.getThresholdData(currentType);
+			const numCheck = Object.values(data.check ?? {}).filter(value => value === true).length;
+
+			if(numCheck < (data?.value ?? 0)) {
+				return {
+					type: currentType,
+					check: `c${numCheck + 1}`,
+				};
+			}
+
+			currentType = {
+				egratinures: 'legeres',
+				legeres: 'graves',
+				graves: 'fatales',
+				fatales: 'morts',
+				morts: 'end',
+			}[currentType];
+		}
+
+		return null;
+	}
+
+	getUpdatePath(type, field, suffix = '') {
+		const prefix = this.isExtended ? `system.attributsmineurs.blessure.extended.${type}` : `system.attributsmineurs.blessure.data.${type}`;
+		return `${prefix}.${field}${suffix}`;
+	}
+
 	prepareData() {
-		const actor = this.parent.parent;
+		const actor = this.actor;
 		const res = actor.caracteristiques.resistance.total;
 		const vol = actor.caracteristiques.volonte.total;
 		const totalRESVOL = res+vol;
@@ -100,46 +316,14 @@ export class BlessureDataModel extends foundry.abstract.DataModel {
 		}
 
 		this.prepareCheck();
+		this.prepareExtendedData();
 		this.prepareMalus();
 	}
 
 	prepareCheck() {
-		const egratinures = this.data.egratinures;
-		const legeres = this.data.legeres;
-		const graves = this.data.graves;
-		const fatales = this.data.fatales;
-		const morts = this.data.morts;
-		let eg = {};
-		let le = {};
-		let gr = {};
-		let fa = {};
-		let mo = {};
-
-		for(let i = 1;i <= egratinures.value;i++) {
-			eg[`c${i}`] = egratinures.check?.[`c${i}`] ?? false;
+		for(const type of BLESSURE_ORDER) {
+			this.data[type].check = this.prepareThresholdCheck(this.data[type].check, this.data[type].value);
 		}
-
-		for(let i = 1;i <= legeres.value;i++) {
-			le[`c${i}`] = legeres.check?.[`c${i}`] ?? false;
-		}
-
-		for(let i = 1;i <= graves.value;i++) {
-			gr[`c${i}`] = graves.check?.[`c${i}`] ?? false;
-		}
-
-		for(let i = 1;i <= fatales.value;i++) {
-			fa[`c${i}`] = fatales.check?.[`c${i}`] ?? false;
-		}
-
-		for(let i = 1;i <= morts.value;i++) {
-			mo[`c${i}`] = morts.check?.[`c${i}`] ?? false;
-		}
-
-		this.data.egratinures.check = eg;
-		this.data.legeres.check = le;
-		this.data.graves.check = gr;
-		this.data.fatales.check = fa;
-		this.data.morts.check = mo;
 	}
 
 	prepareMalus() {

--- a/modules/documents/models/personnage-data-model.mjs
+++ b/modules/documents/models/personnage-data-model.mjs
@@ -3,6 +3,49 @@ import { AttributsDataModel } from './base/attributs-data-model.mjs';
 import { AttributsMineursDataModel } from './base/attributs-mineurs-data-model.mjs';
 import { MagieDataModel } from './base/magie-data-model.mjs';
 
+const BLESSURE_ORDER = ['egratinures', 'legeres', 'graves', 'fatales', 'morts'];
+
+const BLESSURE_DEFAULTS = {
+	egratinures: {
+		label: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Egratinure',
+		max: 10,
+	},
+	legeres: {
+		label: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Legere',
+		max: 20,
+	},
+	graves: {
+		label: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Grave',
+		max: 30,
+	},
+	fatales: {
+		label: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Fatale',
+		max: 40,
+	},
+	morts: {
+		label: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Mort',
+		max: null,
+	},
+};
+
+function createExtendedBlessureData(data = {}) {
+	const extended = {};
+
+	for(const type of BLESSURE_ORDER) {
+		const threshold = data?.[type] ?? {};
+		const defaults = BLESSURE_DEFAULTS[type];
+
+		extended[type] = {
+			label: threshold.label ?? defaults.label,
+			max: threshold.max ?? defaults.max,
+			value: threshold.value ?? 0,
+			check: foundry.utils.deepClone(threshold.check ?? {}),
+		};
+	}
+
+	return extended;
+}
+
 export class PersonnageDataModel extends foundry.abstract.TypeDataModel {
 	static defineSchema() {
 		const {SchemaField, EmbeddedDataField, StringField, NumberField, BooleanField, ObjectField, ArrayField, HTMLField} = foundry.data.fields;
@@ -184,6 +227,27 @@ export class PersonnageDataModel extends foundry.abstract.TypeDataModel {
 	}
 
     static migrateData(source) {
+		const blessure = source?.attributsmineurs?.blessure;
+
+		if(!blessure) return source;
+
+		if(blessure.etendu === undefined) blessure.etendu = false;
+
+		if(!blessure.extended) {
+			const data = {};
+
+			for(const type of BLESSURE_ORDER) {
+				data[type] = {
+					value: blessure.data?.[type]?.value ?? 0,
+					check: blessure.data?.[type]?.check ?? {},
+				};
+			}
+
+			blessure.extended = createExtendedBlessureData(data);
+		} else {
+			blessure.extended = createExtendedBlessureData(blessure.extended);
+		}
+
 		return source;
 	}
 

--- a/modules/helpers/common.mjs
+++ b/modules/helpers/common.mjs
@@ -130,29 +130,31 @@ export function stylingHTML(html) {
     html.parents('.window-content').css("background", game.settings.get('prophecy-2e', 'background'));
 }
 
+function getBlessureLabel(actor, type) {
+    return actor.system.attributsmineurs.blessure.getThresholdLabel(type);
+}
+
+function setBlessureCheckUpdate(actor, update, type, check, value) {
+    const blessure = actor.system.attributsmineurs.blessure;
+
+    blessure.data[type].check[check] = value;
+    blessure.getExtendedThreshold(type).check[check] = value;
+    update['system.attributsmineurs.blessure.edit'] = blessure.edit;
+    update['system.attributsmineurs.blessure.etendu'] = blessure.etendu;
+    update[`system.attributsmineurs.blessure.data.${type}.check.${check}`] = value;
+    update['system.attributsmineurs.blessure.extended'] = foundry.utils.deepClone(blessure.extended);
+}
+
 async function addBlessure(actor, tgt, autoupdate=true) {
     const type = tgt?.['value'] ?? tgt.data("value");
-    let currentType = type;
     let update = {};
     let applied = '';
 
-    while (currentType !== 'end') {
-        const data = actor.system.attributsmineurs.blessure.data[currentType];
-        const numCheck = Object.values(data.check).filter(value => value === true).length;
+    const nextBlessure = actor.system.attributsmineurs.blessure.findNextAvailableThreshold(type);
 
-        if (numCheck < data.value) {
-            applied = currentType;
-            update[`system.attributsmineurs.blessure.data.${currentType}.check.c${numCheck + 1}`] = true;
-            break;
-        } else {
-            currentType = {
-                'egratinures': 'legeres',
-                'legeres': 'graves',
-                'graves': 'fatales',
-                'fatales': 'morts',
-                'morts': 'end',
-            }[currentType];
-        }
+    if(nextBlessure) {
+        applied = nextBlessure.type;
+        setBlessureCheckUpdate(actor, update, nextBlessure.type, nextBlessure.check, true);
     }
 
     await actor.update(update);
@@ -161,11 +163,11 @@ async function addBlessure(actor, tgt, autoupdate=true) {
 
 async function removeBlessure(actor, tgt) {
     const type = tgt.data("value");
-    const data = actor.system.attributsmineurs.blessure.data[type];
+    const data = actor.system.attributsmineurs.blessure.getThresholdData(type);
     const numCheck = Object.values(data.check).filter(value => value === true).length;
     let update = {}
 
-    if(numCheck > 0) update[`system.attributsmineurs.blessure.data.${type}.check.c${numCheck}`] = false;
+    if(numCheck > 0) setBlessureCheckUpdate(actor, update, type, `c${numCheck}`, false);
 
     await actor.update(update);
 }
@@ -1226,41 +1228,15 @@ async function addApplyDmgButton(html, msg) {
 
 async function applyDmg(actor, totaldmg, addToChat=undefined) {
     const chatRollMode = game.settings.get("core", "rollMode");
+    const blessureData = actor.system.attributsmineurs.blessure;
+    const startType = blessureData.getThresholdTypeFromDamage(totaldmg);
 
     let label = '';
-    if(totaldmg <= 10) {
-        const bls = await addBlessure(actor, {value:'egratinures'});
-        label = !bls ? game.i18n.format('PROPHECY.MSG.AlreadyDead', {actor:actor.name}) : game.i18n.format('PROPHECY.MSG.Dmg', {
-            actor:actor.name,
-            type:game.i18n.localize(CONFIG.PROPHECY.Blessures[bls])}
-        );
-    } else if(totaldmg <= 20) {
-        const bls = await addBlessure(actor, {value:'legeres'});
-        label = !bls ? game.i18n.format('PROPHECY.MSG.AlreadyDead', {actor:actor.name}) : game.i18n.format('PROPHECY.MSG.Dmg', {
-            actor:actor.name,
-            type:game.i18n.localize(CONFIG.PROPHECY.Blessures[bls])}
-        );
-
-    } else if(totaldmg <= 30) {
-        const bls = await addBlessure(actor, {value:'graves'});
-        label = !bls ? game.i18n.format('PROPHECY.MSG.AlreadyDead', {actor:actor.name}) : game.i18n.format('PROPHECY.MSG.Dmg', {
-            actor:actor.name,
-            type:game.i18n.localize(CONFIG.PROPHECY.Blessures[bls])}
-        );
-    } else if(totaldmg <= 40) {
-        const bls = await addBlessure(actor, {value:'fatales'});
-        label = !bls ? game.i18n.format('PROPHECY.MSG.AlreadyDead', {actor:actor.name}) : game.i18n.format('PROPHECY.MSG.Dmg', {
-            actor:actor.name,
-            type:game.i18n.localize(CONFIG.PROPHECY.Blessures[bls])}
-        );
-
-    } else if(totaldmg > 40) {
-        const bls = await addBlessure(actor, {value:'morts'});
-        label = !bls ? game.i18n.format('PROPHECY.MSG.AlreadyDead', {actor:actor.name}) : game.i18n.format('PROPHECY.MSG.Dmg', {
-            actor:actor.name,
-            type:game.i18n.localize(CONFIG.PROPHECY.Blessures[bls])}
-        );
-    }
+    const bls = await addBlessure(actor, {value:startType});
+    label = !bls ? game.i18n.format('PROPHECY.MSG.AlreadyDead', {actor:actor.name}) : game.i18n.format('PROPHECY.MSG.Dmg', {
+        actor:actor.name,
+        type:getBlessureLabel(actor, bls)}
+    );
     const list = [];
     list.push(label);
 
@@ -1353,29 +1329,16 @@ async function addApplyMagicButton(html, msg) {
         }
 
         if(spendSubstract > 0) {
-            const dataBlessures = actor.system.attributsmineurs.blessure.data;
+            const blessureData = actor.system.attributsmineurs.blessure;
 
             for(let n = 0;n < spendSubstract;n++) {
-                let currentType = 'egratinures';
+                const nextBlessure = blessureData.findNextAvailableThreshold('egratinures');
 
-                while (currentType !== 'end') {
-                    const data = dataBlessures[currentType];
-                    const numCheck = Object.values(data.check).filter(value => value === true).length;
-
-                    if (numCheck < data.value) {
-                        typeDmg[currentType] += 1;
-                        dataBlessures[currentType]['check'][`c${numCheck + 1}`] = true;
-                        update[`system.attributsmineurs.blessure.data.${currentType}.check.c${numCheck + 1}`] = true;
-                        break;
-                    } else {
-                        currentType = {
-                            'egratinures': 'legeres',
-                            'legeres': 'graves',
-                            'graves': 'fatales',
-                            'fatales': 'morts',
-                            'morts': 'end',
-                        }[currentType];
-                    }
+                if(nextBlessure) {
+                    typeDmg[nextBlessure.type] += 1;
+                    const threshold = blessureData.getThresholdData(nextBlessure.type);
+                    threshold.check[nextBlessure.check] = true;
+                    setBlessureCheckUpdate(actor, update, nextBlessure.type, nextBlessure.check, true);
                 }
             }
 
@@ -1383,14 +1346,14 @@ async function addApplyMagicButton(html, msg) {
                 if(typeDmg[d] === 1) list.push(game.i18n.format('PROPHECY.MSG.Dmgs', {
                     actor:actor.name,
                     blessure:game.i18n.localize("PROPHECY.MSG.BlessureEgratinure"),
-                    type:game.i18n.localize(CONFIG.PROPHECY.Blessures[d]),
+                    type:getBlessureLabel(actor, d),
                 }))
                 else if(typeDmg[d] > 1) list.push(game.i18n.format('PROPHECY.MSG.Dmgs', {
                     actor:actor.name,
                     blessure:game.i18n.format("PROPHECY.MSG.Blessures", {
                         value:typeDmg[d],
                     }),
-                    type:game.i18n.localize(CONFIG.PROPHECY.Blessures[d]),
+                    type:getBlessureLabel(actor, d),
                 }))
             }
         }

--- a/modules/sheets/personnage-actor-sheet.mjs
+++ b/modules/sheets/personnage-actor-sheet.mjs
@@ -1,6 +1,16 @@
 import { commonHTML, generateDialog, sortByWear, sortByWearWpn, stylingHTML } from "../helpers/common.mjs";
 import toggler from '../helpers/toggler.js';
 
+const BLESSURE_ORDER = ['egratinures', 'legeres', 'graves', 'fatales', 'morts'];
+
+const BLESSURE_DEFAULT_LABELS = {
+  egratinures: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Egratinure',
+  legeres: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Legere',
+  graves: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Grave',
+  fatales: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Fatale',
+  morts: 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Mort',
+};
+
 /**
  * @extends {ActorSheet}
  */
@@ -30,6 +40,7 @@ export class PersonnageActorSheet extends ActorSheet {
       this._prepareCharacterItems(context);
 
       context.systemData = context.data.system;
+      context.blessureDisplayData = this.actor.system.attributsmineurs.blessure.displayData;
 
       console.error(context);
 
@@ -202,94 +213,71 @@ export class PersonnageActorSheet extends ActorSheet {
       });
 
       html.find('i.editBlessure').click(async ev => {
-        let others = {
-          id:this.actor._id,
-          name:this.actor.name,
-          bonus:[{
-            class:'egratinure',
-            type:'number',
-            label:game.i18n.localize('PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Egratinure'),
-            min:0,
-            value:Object.values(this.actor.system.attributsmineurs.blessure.data.egratinures.check).length,
-          },
-          {
-            class:'legere',
-            type:'number',
-            label:game.i18n.localize('PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Legere'),
-            min:0,
-            value:Object.values(this.actor.system.attributsmineurs.blessure.data.legeres.check).length,
-          },
-          {
-            class:'grave',
-            type:'number',
-            label:game.i18n.localize('PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Grave'),
-            min:0,
-            value:Object.values(this.actor.system.attributsmineurs.blessure.data.graves.check).length,
-          },
-          {
-            class:'fatale',
-            type:'number',
-            label:game.i18n.localize('PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Fatale'),
-            min:0,
-            value:Object.values(this.actor.system.attributsmineurs.blessure.data.fatales.check).length,
-          },
-          {
-            class:'mort',
-            type:'number',
-            label:game.i18n.localize('PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Mort'),
-            min:0,
-            value:Object.values(this.actor.system.attributsmineurs.blessure.data.morts.check).length,
-          }],
-        };
+        const blessure = this.actor.system.attributsmineurs.blessure;
+        const thresholds = BLESSURE_ORDER.map(type => {
+          const standard = blessure.data[type];
+          const extended = blessure.getExtendedThreshold(type);
+          const label = extended.label?.startsWith('PROPHECY.') ? game.i18n.localize(extended.label) : extended.label;
 
-        generateDialog({type:'other', content:await renderTemplate('systems/prophecy-2e/templates/dialog/askMod.html', {combatants:[others]}), classe:['dialogRoll'], name:game.i18n.localize('PROPHECY.EDIT.Seuil'), validate:async (d) => {
+          return {
+            type,
+            defaultLabel: game.i18n.localize(BLESSURE_DEFAULT_LABELS[type]),
+            label,
+            max: extended.max ?? '',
+            value: blessure.getThresholdData(type).value ?? standard.value,
+          };
+        });
+
+        generateDialog({type:'other', content:await renderTemplate('systems/prophecy-2e/templates/dialog/blessure-thresholds.html', {
+          actorId:this.actor._id,
+          actorName:this.actor.name,
+          etendu:blessure.etendu,
+          thresholds,
+        }), classe:['dialogRoll'], width:650, name:game.i18n.localize('PROPHECY.EDIT.Seuil'), validate:async (d) => {
           const main = $(d.find('div.main'))[0];
-          const egratinure = $(main).find('div.egratinure span.score').text();
-          const legere = $(main).find('div.legere span.score').text();
-          const grave = $(main).find('div.grave span.score').text();
-          const fatale = $(main).find('div.fatale span.score').text();
-          const mort = $(main).find('div.mort span.score').text();
-
+          const useExtended = $(main).find('input[name="etendu"]').is(':checked');
           let update = {};
-          update['system.attributsmineurs.blessure.edit'] = true;
-          update['system.attributsmineurs.blessure.data.egratinures.value'] = parseInt(egratinure);
-          update['system.attributsmineurs.blessure.data.legeres.value'] = parseInt(legere);
-          update['system.attributsmineurs.blessure.data.graves.value'] = parseInt(grave);
-          update['system.attributsmineurs.blessure.data.fatales.value'] = parseInt(fatale);
-          update['system.attributsmineurs.blessure.data.morts.value'] = parseInt(mort);
+          const extendedUpdate = foundry.utils.deepClone(blessure.extended);
 
-          this.actor.update(update);
+          update['system.attributsmineurs.blessure.edit'] = true;
+          update['system.attributsmineurs.blessure.etendu'] = useExtended;
+
+          for(const type of BLESSURE_ORDER) {
+            const row = $(main).find(`tr[data-type="${type}"]`);
+            const activeThreshold = blessure.getThresholdData(type);
+            const value = Math.max(parseInt(row.find('input.threshold-value').val()) || 0, 0);
+            const rawLabel = row.find('input.threshold-label').val().trim();
+            const rawMax = row.find('input.threshold-max').val().trim();
+            const defaultLabel = game.i18n.localize(BLESSURE_DEFAULT_LABELS[type]);
+            const label = !rawLabel || rawLabel === defaultLabel ? BLESSURE_DEFAULT_LABELS[type] : rawLabel;
+            const max = rawMax === '' ? null : Math.max(parseInt(rawMax) || 0, 0);
+            const check = blessure.prepareThresholdCheck(activeThreshold.check, value);
+
+            update[`system.attributsmineurs.blessure.data.${type}.value`] = value;
+            update[`system.attributsmineurs.blessure.data.${type}.check`] = check;
+            extendedUpdate[type].value = value;
+            extendedUpdate[type].check = check;
+            extendedUpdate[type].label = label;
+            extendedUpdate[type].max = max;
+          }
+
+          update['system.attributsmineurs.blessure.extended'] = extendedUpdate;
+
+          await this.actor.update(update);
 
         }, render:(html) => {
           stylingHTML(html);
-          toggler.init(this.actor._id, html);
 
-          html.find('.data .inner .plus').click(async ev => {
-              const tgt = $(ev.currentTarget);
-              const master = tgt.data('class');
-              const max = parseInt(tgt.data('max'));
-              let mScore = tgt.parents(`.${master}`).find('span.score');
-              let score = parseInt(mScore.text());
+          const toggleExtendedFields = () => {
+            const useExtended = html.find('input[name="etendu"]').is(':checked');
+            html.find('.extended-field').prop('disabled', !useExtended);
+          };
 
-              if(score === max) {
-                  ui.notifications.warn(game.i18n.localize('PROPHECY.WRN.MaitriseMax'));
-                  return;
-              }
-
-              mScore.text(score+1);
+          html.find('input[name="etendu"]').change(() => {
+            toggleExtendedFields();
           });
 
-          html.find('.data .inner .minus').click(async ev => {
-              const tgt = $(ev.currentTarget);
-              const master = tgt.data('class');
-              const min = parseInt(tgt.data('min'));
-              let mScore = tgt.parents(`.${master}`).find('span.score');
-              let score = parseInt(mScore.text());
-
-              if(score === min) return;
-
-              mScore.text(score-1);
-          });
+          toggleExtendedFields();
         }});
       });
     }

--- a/templates/dialog/blessure-thresholds.html
+++ b/templates/dialog/blessure-thresholds.html
@@ -1,0 +1,35 @@
+<div class="main blessure-thresholds" data-id="{{actorId}}">
+    <div class="threshold-mode">
+        <label>
+            <input type="checkbox" name="etendu" {{#if etendu}}checked{{/if}}>
+            {{localize 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.ExtendedMode'}}
+        </label>
+    </div>
+
+    <table class="threshold-table">
+        <thead>
+            <tr>
+                <th>{{localize 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.DefaultLabel'}}</th>
+                <th>{{localize 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.CustomLabel'}}</th>
+                <th>{{localize 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.MaxThreshold'}}</th>
+                <th>{{localize 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Boxes'}}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{#each thresholds}}
+            <tr data-type="{{type}}">
+                <td>{{defaultLabel}}</td>
+                <td>
+                    <input class="threshold-label extended-field" type="text" value="{{label}}">
+                </td>
+                <td>
+                    <input class="threshold-max extended-field" type="number" min="0" value="{{max}}">
+                </td>
+                <td>
+                    <input class="threshold-value" type="number" min="0" value="{{value}}">
+                </td>
+            </tr>
+            {{/each}}
+        </tbody>
+    </table>
+</div>

--- a/templates/parts/subparts/blessures.html
+++ b/templates/parts/subparts/blessures.html
@@ -6,15 +6,15 @@
         {{/if}}
     </h1>
 
-    {{#each systemData.attributsmineurs.blessure.data as |key list|}}
+    {{#each blessureDisplayData as |entry|}}
     <div class="data">
-        <i class="fa-solid fa-skull clickable" data-type="blessure" data-value="{{list}}" title="{{localize 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Subir'}}"></i>
-        <i class="fa-solid fa-heart clickable" data-type="heal" data-value="{{list}}" title="{{localize 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Soin'}}"></i>
-        <span class="label">{{localize (translate 'Blessures' list)}}</span>
-        <span class="sublabel">{{translate 'SeuilsBlessures' list}}</span>
+        <i class="fa-solid fa-skull clickable" data-type="blessure" data-value="{{entry.type}}" title="{{localize 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Subir'}}"></i>
+        <i class="fa-solid fa-heart clickable" data-type="heal" data-value="{{entry.type}}" title="{{localize 'PROPHECY.ATTRIBUTSMINEURS.BLESSURES.Soin'}}"></i>
+        <span class="label">{{entry.label}}</span>
+        <span class="sublabel">{{entry.range}}</span>
 
         <div class="check">
-            {{#each key.check as |kBle Blist|}}
+            {{#each entry.check as |kBle Blist|}}
                 <i class="{{ifThen kBle 'fa-solid' 'fa-light'}} fa-circle"></i>
             {{/each}}
         </div>


### PR DESCRIPTION
Proposition d'évolution du système de blessures pour permettre de créer des PNJ ayant des seuils différents des classiques 1-10, 11-20, 21-30, 31-40 et 41+
Cela est nécessaire pour certains types de créatures comme l'aigle ou le cheval, ou pour certains pnj définis dans les scénarios (par exemple le mâle mérog pour le scénario retour au sources du livre de base 2ème édition).
J'ai ajouté un mode "étendu" sur la définition des seuils de blessures des pnj. Dans ce mode il est possible de définir des libellés de blessures spécifiques et de choisir la valeur du seuil de blessures.
Les lignes pour lesquelles il n'y a pas de cases de blessures ne sont plus affichées sur la feuille de personnage et les tranches d'application des blessures sont automatiquement calculés à partir des seuils max définis.
Si on n'est pas en mode étendu, le système de blessures fonctionne comme avant.
Le mode étendu est également géré lors de l'application des blessures dans un combat.